### PR TITLE
Improve pretty output of `File` objects

### DIFF
--- a/lib/sumi.rb
+++ b/lib/sumi.rb
@@ -76,8 +76,8 @@ module Sumi
 			end
 		when Module
 			object.name
-		when Pathname
-			%(Pathname("#{object.to_path}"))
+		when Pathname, File
+			%(#{object.class.name}("#{object.to_path}"))
 		when DateTime, Time
 			%(#{object.class.name}("#{object}"))
 		when Exception

--- a/test/inspect.test.rb
+++ b/test/inspect.test.rb
@@ -404,3 +404,11 @@ test "exception" do
 		ArgumentError("message")
 	RUBY
 end
+
+test "file" do
+	file = Tempfile.create
+
+	assert_equal_ruby Sumi.inspect(file), <<~RUBY.chomp
+		File("#{file.to_path}")
+	RUBY
+end


### PR DESCRIPTION
This pull request adds support for pretty-printing `File` objects in the `Sumi.inspect` method.

**Before:**

```ruby
irb(main):001> puts Sumi.inspect(Tempfile.create)
File("")

irb(main):002> puts Sumi.inspect(File.open("file.txt"))
File("")
```

**After:**
```ruby
irb(main):001> puts Sumi.inspect(Tempfile.create)
File("/var/folders/hb/yph9ymkx6b75my0g9mylpb640000gn/T/20250131-28506-uzp6gj")

irb(main):002> puts Sumi.inspect(File.open("file.txt"))
File("file.txt")
```