### PR TITLE
Improve pretty output of `Struct` objects

### DIFF
--- a/lib/sumi.rb
+++ b/lib/sumi.rb
@@ -86,7 +86,7 @@ module Sumi
 			object.inspect
 		when defined?(Date) && Date
 			%(#{object.class.name}("#{object}"))
-		when defined?(Data) && Data
+		when Struct, (defined?(Data) && Data)
 			buffer = +""
 			members = object.members.take(max_instance_variables) # TODO: either rename max_instance_variables to max_properties or define a max_members specifcally for data objects
 			total_count = object.members.length

--- a/test/inspect.test.rb
+++ b/test/inspect.test.rb
@@ -15,6 +15,36 @@ test "object with no properties" do
 	assert_equal_ruby Sumi.inspect(Object.new), %(Object())
 end
 
+
+test "struct" do
+	customer = Struct.new(:name, :address) do
+		def self.name
+			"Customer"
+		end
+	end
+
+	assert_equal_ruby Sumi.inspect(customer.new("Dave", "123 Main")), <<~RUBY.chomp
+    Customer(
+      name: "Dave",
+      address: "123 Main",
+    )
+	RUBY
+end
+
+if (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3"))
+	test "empty struct" do
+		empty = Struct.new do
+			def self.name
+				"Empty"
+			end
+		end
+
+		assert_equal_ruby Sumi.inspect(empty.new), <<~RUBY.chomp
+			Empty()
+		RUBY
+	end
+end
+
 if (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2"))
 	test "data objects" do
 		measure = Data.define(:amount, :unit) do
@@ -402,32 +432,5 @@ test "exception" do
 
 	assert_equal_ruby Sumi.inspect(exception), <<~RUBY.chomp
 		ArgumentError("message")
-	RUBY
-end
-
-test "struct" do
-	customer = Struct.new(:name, :address) do
-		def self.name
-			"Customer"
-		end
-	end
-
-	assert_equal_ruby Sumi.inspect(customer.new("Dave", "123 Main")), <<~RUBY.chomp
-    Customer(
-      name: "Dave",
-      address: "123 Main",
-    )
-	RUBY
-end
-
-test "empty struct" do
-	empty = Struct.new do
-		def self.name
-			"Empty"
-		end
-	end
-
-	assert_equal_ruby Sumi.inspect(empty.new), <<~RUBY.chomp
-    Empty()
 	RUBY
 end

--- a/test/inspect.test.rb
+++ b/test/inspect.test.rb
@@ -404,3 +404,30 @@ test "exception" do
 		ArgumentError("message")
 	RUBY
 end
+
+test "struct" do
+	customer = Struct.new(:name, :address) do
+		def self.name
+			"Customer"
+		end
+	end
+
+	assert_equal_ruby Sumi.inspect(customer.new("Dave", "123 Main")), <<~RUBY.chomp
+    Customer(
+      name: "Dave",
+      address: "123 Main",
+    )
+	RUBY
+end
+
+test "empty struct" do
+	empty = Struct.new do
+		def self.name
+			"Empty"
+		end
+	end
+
+	assert_equal_ruby Sumi.inspect(empty.new), <<~RUBY.chomp
+    Empty()
+	RUBY
+end

--- a/test/inspect.test.rb
+++ b/test/inspect.test.rb
@@ -15,7 +15,6 @@ test "object with no properties" do
 	assert_equal_ruby Sumi.inspect(Object.new), %(Object())
 end
 
-
 test "struct" do
 	customer = Struct.new(:name, :address) do
 		def self.name


### PR DESCRIPTION
This pull request adds support for pretty-printing `Struct` objects in the `Sumi.inspect` method.

**Before:**

```ruby
irb(main):001> Customer = Struct.new(:name, :address)

irb(main):002> puts Sumi.inspect(Customer.new("Dave", "123 Main"))
Customer()
```

**After:**
```ruby
irb(main):001> Customer = Struct.new(:name, :address)

irb(main):002> puts Sumi.inspect(Customer.new("Dave", "123 Main"))
Customer(
  name: "Dave",
  address: "123 Main",
)
```