### PR TITLE
Improve pretty output of `MatchData` objects

### DIFF
--- a/lib/sumi.rb
+++ b/lib/sumi.rb
@@ -78,7 +78,7 @@ module Sumi
 			object.name
 		when Pathname, File
 			%(#{object.class.name}("#{object.to_path}"))
-		when DateTime, Time
+		when MatchData, DateTime, Time
 			%(#{object.class.name}("#{object}"))
 		when Exception
 			%(#{object.class.name}("#{object.message}"))

--- a/test/inspect.test.rb
+++ b/test/inspect.test.rb
@@ -441,3 +441,11 @@ test "file" do
 		File("#{file.to_path}")
 	RUBY
 end
+
+test "match data" do
+	match_data = "String".match(/.+/)
+
+	assert_equal_ruby Sumi.inspect(match_data), <<~RUBY.chomp
+		MatchData("String")
+	RUBY
+end


### PR DESCRIPTION
This pull request adds support for pretty-printing `MatchData` objects in the `Sumi.inspect` method.

**Before:**

```ruby
irb(main):001> match_data = "String".match(/.+/)
irb(main):002> puts Sumi.inspect(match_data)
MatchData("")
```

**After:**
```ruby
irb(main):001> match_data = "String".match(/.+/)
irb(main):002> puts Sumi.inspect(match_data)
MatchData("String")
```