### PR TITLE
Check for `Pathname` to be defined

### DIFF
--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -48,7 +48,7 @@ class PrettyPlease::Prettifier
 				push object.inspect
 			when Module
 				push object.name
-			when Pathname, File
+			when File, defined?(Pathname) && Pathname
 				push %(#{object.class.name}("#{object.to_path}"))
 			when MatchData, (defined?(Date) && Date), (defined?(DateTime) && DateTime), (defined?(Time) && Time), (defined?(URI) && URI)
 				push %(#{object.class.name}("#{object}"))


### PR DESCRIPTION
In a pure Ruby project the `Difftastic.pretty` (which calls `PrettyPlease.prettify` under the hood) would fail with:

```
❯ rake test
Run options: --seed 7222

# Running:

.Minitest::Difftastic error: #<NameError: uninitialized constant Difftastic::Pathname> (/Users/marcoroth/.local/share/mise
/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/difftastic-0.4.0-arm64-darwin/lib/difftastic.rb:135:in 'Difftastic.pretty')
F

Failure:
Minitest::TestDifftastic#test_hello [test/minitest/test_difftastic.rb:11]:
Expected: "hello"
  Actual: "world"