### PR TITLE
Improve pretty output of `ActiveRecord::Base` objects

### DIFF
--- a/config/quickdraw.rb
+++ b/config/quickdraw.rb
@@ -23,34 +23,34 @@ class Example
 end
 
 module ActiveRecord
-  if defined?(ActiveRecord::Base)
-    raise "ActiveRecord::Base is already defined, remove the 'ActiveRecord::Base' stub in the 'config/quickdraw.rb' file."
-  end
+	if defined?(ActiveRecord::Base)
+		raise "ActiveRecord::Base is already defined, remove the 'ActiveRecord::Base' stub in the 'config/quickdraw.rb' file."
+	end
 
-  class Base
-  end
+	class Base
+	end
 end
 
 class TestModel < ActiveRecord::Base
-  attr_reader :attributes
+	attr_reader :attributes
 
-  def initialize
-    @attributes = {
-      "id" => 1,
-      "name" => "Test Model",
-      "created_at" => Time.new("2025-02-06 01:02:03 UTC"),
-      "updated_at" => Time.new("2025-02-06 04:05:06 UTC"),
-      "date" => Date.parse("2025-02-06"),
-      "tags" => ["tag_1", "tag_2", "tag_3"],
-      "attribute_1" => "value_1",
-      "attribute_2" => "value_2",
-      "attribute_3" => "value_3",
-      "attribute_4" => "value_4",
-      "attribute_5" => "value_5",
-      "attribute_6" => "value_6",
-      "attribute_7" => "value_7",
-      "attribute_8" => "value_8",
-      "attribute_9" => "value_9",
-    }
-  end
+	def initialize
+		@attributes = {
+			"id" => 1,
+			"name" => "Test Model",
+			"created_at" => Time.new("2025-02-06 01:02:03 UTC"),
+			"updated_at" => Time.new("2025-02-06 04:05:06 UTC"),
+			"date" => Date.parse("2025-02-06"),
+			"tags" => ["tag_1", "tag_2", "tag_3"],
+			"attribute_1" => "value_1",
+			"attribute_2" => "value_2",
+			"attribute_3" => "value_3",
+			"attribute_4" => "value_4",
+			"attribute_5" => "value_5",
+			"attribute_6" => "value_6",
+			"attribute_7" => "value_7",
+			"attribute_8" => "value_8",
+			"attribute_9" => "value_9",
+		}
+	end
 end

--- a/config/quickdraw.rb
+++ b/config/quickdraw.rb
@@ -14,6 +14,7 @@ end
 Bundler.require :test
 
 require "pretty_please"
+require "time"
 
 class Example
 	def initialize
@@ -38,8 +39,8 @@ class TestModel < ActiveRecord::Base
 		@attributes = {
 			"id" => 1,
 			"name" => "Test Model",
-			"created_at" => Time.new("2025-02-06 01:02:03 UTC"),
-			"updated_at" => Time.new("2025-02-06 04:05:06 UTC"),
+			"created_at" => Time.parse("2025-02-06 01:02:03 UTC"),
+			"updated_at" => Time.parse("2025-02-06 04:05:06 UTC"),
 			"date" => Date.parse("2025-02-06"),
 			"tags" => ["tag_1", "tag_2", "tag_3"],
 			"attribute_1" => "value_1",

--- a/config/quickdraw.rb
+++ b/config/quickdraw.rb
@@ -21,3 +21,36 @@ class Example
 		@bar = [2, 3, 4]
 	end
 end
+
+module ActiveRecord
+  if defined?(ActiveRecord::Base)
+    raise "ActiveRecord::Base is already defined, remove the 'ActiveRecord::Base' stub in the 'config/quickdraw.rb' file."
+  end
+
+  class Base
+  end
+end
+
+class TestModel < ActiveRecord::Base
+  attr_reader :attributes
+
+  def initialize
+    @attributes = {
+      "id" => 1,
+      "name" => "Test Model",
+      "created_at" => Time.new("2025-02-06 01:02:03 UTC"),
+      "updated_at" => Time.new("2025-02-06 04:05:06 UTC"),
+      "date" => Date.parse("2025-02-06"),
+      "tags" => ["tag_1", "tag_2", "tag_3"],
+      "attribute_1" => "value_1",
+      "attribute_2" => "value_2",
+      "attribute_3" => "value_3",
+      "attribute_4" => "value_4",
+      "attribute_5" => "value_5",
+      "attribute_6" => "value_6",
+      "attribute_7" => "value_7",
+      "attribute_8" => "value_8",
+      "attribute_9" => "value_9",
+    }
+  end
+end

--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -81,6 +81,17 @@ class PrettyPlease::Prettifier
 				push "Set["
 				map(object) { |it| capture { prettify(it) } }
 				push "]"
+			when defined?(ActiveRecord::Base) && ActiveRecord::Base
+				@max_items_before = @max_items
+				@max_items = object.attributes.length
+
+				push "#{object.class.name}("
+				map(object.attributes) do |(key, value)|
+					"#{key}: #{capture { prettify(value) }}"
+				end
+				push ")"
+
+				@max_items = @max_items_before				
 			else
 				push "#{object.class.name}("
 				map(object.instance_variables) do |name|

--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -82,7 +82,7 @@ class PrettyPlease::Prettifier
 				map(object) { |it| capture { prettify(it) } }
 				push "]"
 			when defined?(ActiveRecord::Base) && ActiveRecord::Base
-				@max_items_before = @max_items
+				max_items_before = @max_items
 				@max_items = object.attributes.length
 
 				push "#{object.class.name}("
@@ -91,7 +91,7 @@ class PrettyPlease::Prettifier
 				end
 				push ")"
 
-				@max_items = @max_items_before
+				@max_items = max_items_before
 			else
 				push "#{object.class.name}("
 				map(object.instance_variables) do |name|

--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -91,7 +91,7 @@ class PrettyPlease::Prettifier
 				end
 				push ")"
 
-				@max_items = @max_items_before				
+				@max_items = @max_items_before
 			else
 				push "#{object.class.name}("
 				map(object.instance_variables) do |name|

--- a/test/prettify.test.rb
+++ b/test/prettify.test.rb
@@ -298,27 +298,27 @@ test "self-referencing" do
 	]
 
 	assert_equal_ruby prettify(object, max_depth: 10), <<~RUBY.chomp
-	{
-	  id: 1,
-	  array: [1, 2, 3],
-	  parent: {
-	    object: self,
-	    self_twice: [self, self],
-	    children: [
-	      self,
-	      {
-	        id: 2,
-	        array: [3, 2, 1],
-	        previous_sibling: self,
-	      },
-	    ],
-	  },
-	  next_sibling: {
-	    id: 2,
-	    array: [3, 2, 1],
-	    previous_sibling: self,
-	  },
-	}
+		{
+		  id: 1,
+		  array: [1, 2, 3],
+		  parent: {
+		    object: self,
+		    self_twice: [self, self],
+		    children: [
+		      self,
+		      {
+		        id: 2,
+		        array: [3, 2, 1],
+		        previous_sibling: self,
+		      },
+		    ],
+		  },
+		  next_sibling: {
+		    id: 2,
+		    array: [3, 2, 1],
+		    previous_sibling: self,
+		  },
+		}
 	RUBY
 end
 
@@ -414,23 +414,23 @@ test "custom inspect" do
 end
 
 test "ActiveRecord::Base Model" do
-  assert_equal_ruby prettify(TestModel.new), <<~RUBY.chomp
-    TestModel(
-      id: 1,
-      name: "Test Model",
-      created_at: Time("2025-02-06 01:02:03 UTC"),
-      updated_at: Time("2025-02-06 04:05:06 UTC"),
-      date: Date("2025-02-06"),
-      tags: ["tag_1", "tag_2", "tag_3"],
-      attribute_1: "value_1",
-      attribute_2: "value_2",
-      attribute_3: "value_3",
-      attribute_4: "value_4",
-      attribute_5: "value_5",
-      attribute_6: "value_6",
-      attribute_7: "value_7",
-      attribute_8: "value_8",
-      attribute_9: "value_9",
-    )
-  RUBY
+	assert_equal_ruby prettify(TestModel.new), <<~RUBY.chomp
+		TestModel(
+		  id: 1,
+		  name: "Test Model",
+		  created_at: Time("2025-02-06 01:02:03 UTC"),
+		  updated_at: Time("2025-02-06 04:05:06 UTC"),
+		  date: Date("2025-02-06"),
+		  tags: ["tag_1", "tag_2", "tag_3"],
+		  attribute_1: "value_1",
+		  attribute_2: "value_2",
+		  attribute_3: "value_3",
+		  attribute_4: "value_4",
+		  attribute_5: "value_5",
+		  attribute_6: "value_6",
+		  attribute_7: "value_7",
+		  attribute_8: "value_8",
+		  attribute_9: "value_9",
+		)
+	RUBY
 end

--- a/test/prettify.test.rb
+++ b/test/prettify.test.rb
@@ -412,3 +412,25 @@ test "custom inspect" do
 		Custom[1, 2, 3]
 	RUBY
 end
+
+test "ActiveRecord::Base Model" do
+  assert_equal_ruby prettify(TestModel.new), <<~RUBY.chomp
+    TestModel(
+      id: 1,
+      name: "Test Model",
+      created_at: Time("2025-02-06 01:02:03 UTC"),
+      updated_at: Time("2025-02-06 04:05:06 UTC"),
+      date: Date("2025-02-06"),
+      tags: ["tag_1", "tag_2", "tag_3"],
+      attribute_1: "value_1",
+      attribute_2: "value_2",
+      attribute_3: "value_3",
+      attribute_4: "value_4",
+      attribute_5: "value_5",
+      attribute_6: "value_6",
+      attribute_7: "value_7",
+      attribute_8: "value_8",
+      attribute_9: "value_9",
+    )
+  RUBY
+end


### PR DESCRIPTION
This pull request improves the  output of `ActiveRecord::Base` objects. The before output would just list all instance variables, which might also be interesting. But I think in the current form it's not really useful because it shows only the first 10 instance variables which aren't the most useful when comparing two `ActiveRecord::Base` objects with each other.

I think for now it makes sense that we show all attributes. Later we can think about if it would also make sense the include instance variables like `@new_record`, `@readonly`, `@primary_key` and similar.

|Before (First Page) | After |
| --- | --- | 
| ![CleanShot 2025-02-06 at 17 08 00@2x](https://github.com/user-attachments/assets/5827f8f0-3649-4d11-84de-c89379e5d544) | ![CleanShot 2025-02-06 at 17 07 13@2x](https://github.com/user-attachments/assets/08943690-3e5d-40fb-ace1-8bbc6ed15263) |

Resolves #22.