### PR TITLE
Add support for prettifying `Queue` and `SizedQueue` objects

### DIFF
--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -51,6 +51,10 @@ class PrettyPlease::Prettifier
 				push object.name
 			when File, defined?(Pathname) && Pathname
 				push %(#{object.class.name}("#{object.to_path}"))
+			when SizedQueue
+				push %(#{object.class.name}(#{object.length}/#{object.max}))
+			when Queue
+				push %(#{object.class.name}(#{object.length}))
 			when MatchData, (defined?(Date) && Date), (defined?(DateTime) && DateTime), (defined?(Time) && Time), (defined?(URI) && URI)
 				push %(#{object.class.name}("#{object}"))
 			when Array

--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -52,9 +52,9 @@ class PrettyPlease::Prettifier
 			when File, defined?(Pathname) && Pathname
 				push %(#{object.class.name}("#{object.to_path}"))
 			when SizedQueue
-				push %(#{object.class.name}(#{object.length}/#{object.max}))
+				push %(#{object.class.name}(size: #{object.size}, max: #{object.max}))
 			when Queue
-				push %(#{object.class.name}(#{object.length}))
+				push %(#{object.class.name}(size: #{object.size}))
 			when MatchData, (defined?(Date) && Date), (defined?(DateTime) && DateTime), (defined?(Time) && Time), (defined?(URI) && URI)
 				push %(#{object.class.name}("#{object}"))
 			when Array

--- a/test/prettify.test.rb
+++ b/test/prettify.test.rb
@@ -434,3 +434,23 @@ test "ActiveRecord::Base Model" do
 		)
 	RUBY
 end
+
+test "Queue" do
+	if RUBY_ENGINE == "truffleruby"
+		assert_equal_ruby prettify(Queue.new), "Queue(0)"
+		assert_equal_ruby prettify(Queue.new.push(1)), "Queue(1)"
+	else
+		assert_equal_ruby prettify(Queue.new), "Thread::Queue(0)"
+		assert_equal_ruby prettify(Queue.new.push(1)), "Thread::Queue(1)"
+	end
+end
+
+test "SizedQueue" do
+	if RUBY_ENGINE == "truffleruby"
+		assert_equal_ruby prettify(SizedQueue.new(10)), "SizedQueue(0/10)"
+		assert_equal_ruby prettify(SizedQueue.new(10).push(1)), "SizedQueue(1/10)"
+	else
+		assert_equal_ruby prettify(SizedQueue.new(10)), "Thread::SizedQueue(0/10)"
+		assert_equal_ruby prettify(SizedQueue.new(10).push(1)), "Thread::SizedQueue(1/10)"
+	end
+end

--- a/test/prettify.test.rb
+++ b/test/prettify.test.rb
@@ -437,20 +437,20 @@ end
 
 test "Queue" do
 	if RUBY_ENGINE == "truffleruby"
-		assert_equal_ruby prettify(Queue.new), "Queue(0)"
-		assert_equal_ruby prettify(Queue.new.push(1)), "Queue(1)"
+		assert_equal_ruby prettify(Queue.new), "Queue(size: 0)"
+		assert_equal_ruby prettify(Queue.new.push(1)), "Queue(size: 1)"
 	else
-		assert_equal_ruby prettify(Queue.new), "Thread::Queue(0)"
-		assert_equal_ruby prettify(Queue.new.push(1)), "Thread::Queue(1)"
+		assert_equal_ruby prettify(Queue.new), "Thread::Queue(size: 0)"
+		assert_equal_ruby prettify(Queue.new.push(1)), "Thread::Queue(size: 1)"
 	end
 end
 
 test "SizedQueue" do
 	if RUBY_ENGINE == "truffleruby"
-		assert_equal_ruby prettify(SizedQueue.new(10)), "SizedQueue(0/10)"
-		assert_equal_ruby prettify(SizedQueue.new(10).push(1)), "SizedQueue(1/10)"
+		assert_equal_ruby prettify(SizedQueue.new(10)), "SizedQueue(size: 0, max: 10)"
+		assert_equal_ruby prettify(SizedQueue.new(10).push(1)), "SizedQueue(size: 1, max: 10)"
 	else
-		assert_equal_ruby prettify(SizedQueue.new(10)), "Thread::SizedQueue(0/10)"
-		assert_equal_ruby prettify(SizedQueue.new(10).push(1)), "Thread::SizedQueue(1/10)"
+		assert_equal_ruby prettify(SizedQueue.new(10)), "Thread::SizedQueue(size: 0, max: 10)"
+		assert_equal_ruby prettify(SizedQueue.new(10).push(1)), "Thread::SizedQueue(size: 1, max: 10)"
 	end
 end


### PR DESCRIPTION
This pull request adds support for prettifying `Queue` and `SizedQueue` objects.

**Before:**

```ruby
irb(main):001> PrettyPlease.prettify(Queue.new)
=> "Thread::Queue()"

irb(main):002> PrettyPlease.prettify(Queue.new.push(1))
=> "Thread::Queue()"

irb(main):003> PrettyPlease.prettify(SizedQueue.new(10))
=> "Thread::SizedQueue()"

irb(main):004> PrettyPlease.prettify(SizedQueue.new(10).push(1))
=> "Thread::SizedQueue()"
```

**After:**

```ruby
irb(main):001> PrettyPlease.prettify(Queue.new)
=> "Thread::Queue(size: 0)"

irb(main):002> PrettyPlease.prettify(Queue.new.push(1))
=> "Thread::Queue(size: 1)"

irb(main):003> PrettyPlease.prettify(SizedQueue.new(10))
=> "Thread::SizedQueue(size: 0, max: 10)"

irb(main):004> PrettyPlease.prettify(SizedQueue.new(10).push(1))
=> "Thread::SizedQueue(size: 1, max: 10)"
```