### PR TITLE
Fix handling of an array of nils

### DIFF
--- a/lib/pretty_please/prettifier.rb
+++ b/lib/pretty_please/prettifier.rb
@@ -116,7 +116,7 @@ class PrettyPlease::Prettifier
 
 		@running_depth += 1
 
-		return unless object.any?
+		return unless object.size > 0
 
 		length = 0
 		length += around_inline.bytesize * 2 if around_inline

--- a/test/prettify.test.rb
+++ b/test/prettify.test.rb
@@ -241,6 +241,12 @@ test "long arrays" do
 	RUBY
 end
 
+test "array of nils" do
+	assert_equal_ruby prettify([nil, nil]), <<~RUBY.chomp
+		[nil, nil]
+	RUBY
+end
+
 test "module and class" do
 	assert_equal_ruby prettify([Difftastic, Integer]), <<~RUBY.chomp
 		[Difftastic, Integer]


### PR DESCRIPTION
As originally reported in https://github.com/joeldrapper/difftastic-ruby/issues/32