### PR TITLE
Load Bundler in `bin/console`

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "irb"
 require "pretty_please"
 


### PR DESCRIPTION
If you already have a version of `pretty_please` installed, then `bin/console` loads that instead of the one in `lib/`.

(the template used by `bundle gem` already [has](https://github.com/rubygems/rubygems/blob/f8ff2ceeef847b95c43a265fc2ab5023fbecb8d4/bundler/lib/bundler/templates/newgem/bin/console.tt#L4) this)